### PR TITLE
pycrate_mobile: Fix TimeZoneTime encode

### DIFF
--- a/pycrate_mobile/TS24008_IE.py
+++ b/pycrate_mobile/TS24008_IE.py
@@ -1040,7 +1040,7 @@ class TimeZoneTime(Envelope):
         self['Hour'].encode( ts.tm_hour )
         self['Min'].encode( ts.tm_min  )
         self['Sec'].encode( ts.tm_sec )
-        self['TZ'].encode( tz )
+        self['TimeZone'].encode( tz )
     
     def decode(self):
         """decode the value of the TimeZoneTime into a Python struct_time and 


### PR DESCRIPTION
This should fix the typo in the encode function that lead to an exception, when using the `struct_time`.

I came across this with a small example:

```python
    from pycrate_mobile.TS24008_IE import TimeZoneTime
    from time import gmtime

    uttz = TimeZoneTime()
    curr = gmtime()
    uttz.encode(curr)
```

Which led to the following output:

```bash
  File ".venv/lib/python3.12/site-packages/pycrate_mobile/TS24008_IE.py", line 1043, in encode
    self['TZ'].encode( tz )
    ~~~~^^^^^^
  File ".venv/lib/python3.12/site-packages/pycrate_core/elt.py", line 2146, in __getitem__
    raise(EltErr('{0} [__getitem__] str item: {1}'.format(self._name, err)))
pycrate_core.elt.EltErr: TimeZoneTime [__getitem__] str item: 'TZ' is not in list
```

The commit renames the member that is accessed to `TimeZone` (like below) ^^

Cheers,
Eduard