### PR TITLE
NAS MM: fix selection for serviceLevelAAServerAddress

### DIFF
--- a/pycrate_mobile/TS24501_IE.py
+++ b/pycrate_mobile/TS24501_IE.py
@@ -301,7 +301,7 @@ class _ServiceLevelAAServerAddr(Envelope):
                     Buf('IPv6', bl=128, rep=REPR_HEX))),
             4 : FQDN()},
             DEFAULT=Buf('unk', rep=REPR_HEX),
-            sel=lambda self: self.get_env()[1].get_val()
+            sel=lambda self: self.get_env()[2].get_val()
             )
         )
     


### PR DESCRIPTION
The offset was previously pointing to the length with led to selecting `unk` as the payload. Setting the offset to the `Type` field should fix this, I believe :)